### PR TITLE
Bug/18 Fix Discussion Link In Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
-    - name: ❗️ All other issues
-      url: https://github.com/Tada5hi/typescript-template/discussions
-      about: |
-          Please use GitHub Discussions for other issues and asking questions.
+  - name: ❗️ All other issues
+    url: https://github.com/PrivateAIM/node-message-broker/discussions
+    about: |
+      Please use GitHub Discussions for other issues and asking questions.


### PR DESCRIPTION
Fixes the discussions link for issues that do not fall into one of the pre-defined categories.
The link was pointing to the repository that has been used as a template.

Fixes #18 