### PR TITLE
Feature/51 Run GitHub Actions On Tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [develop, master, next, beta, alpha]
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+**
   pull_request:
     branches: [develop, master, next, beta, alpha]
 


### PR DESCRIPTION
Lets GitHub actions run whenever a new tag is pushed. The tag needs to conform to semantic versioning standards to be taken into account when triggering the pipeline.

Resolves #51 