### PR TITLE
Feature/71 Revise Message Subscription Endpoint

### DIFF
--- a/src/server/message/subscription/subscription.controller.ts
+++ b/src/server/message/subscription/subscription.controller.ts
@@ -1,10 +1,12 @@
 /* eslint-disable max-classes-per-file */
 // Disabled to allow keeping validation classes close to where they are used!
 import {
-    Body, Controller, Get, HttpCode, Param, Post, Req, Res, UseGuards,
+    BadGatewayException,
+    Body, Controller, Get, HttpCode, HttpException, InternalServerErrorException, NotFoundException, Param, Post, Req, Res, UseGuards,
 } from '@nestjs/common';
-import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import { IsUrl } from 'class-validator';
 import { Request, Response } from 'express';
+import { APIClient } from '@privateaim/core';
 import type { SubscriptionDto } from './subscription.service';
 import { MessageSubscriptionService } from './subscription.service';
 import { AuthGuard } from '../../auth/auth.guard';
@@ -14,39 +16,67 @@ import { AuthGuard } from '../../auth/auth.guard';
  * Makes use of auto-validation using `class-validator`.
  */
 class AddSubscriptionRequestBody {
-    @IsString()
-    @IsNotEmpty()
-        analysisId: string;
-
     @IsUrl({ require_tld: false })
         webhookUrl: URL;
     // TODO: might need some auth information as well (left out for brevity at the moment)
 }
 
+// TODO: this somehow needs to be handled by the API Client -> maybe introduce a wrapper later on
+function handleHubApiError(err: any, analysisId: string) {
+    if (err.statusCode !== undefined) {
+        if ((err.statusCode as number) === 404) {
+            throw new NotFoundException(`analysis '${analysisId}' does not exist`);
+        }
+
+        if ((err.statusCode as number) >= 500) {
+            throw new BadGatewayException(`cannot check existence of analysis '${analysisId}'`, {
+                cause: err,
+                description: 'unrecoverable error when requesting central side (hub)',
+            });
+        }
+    } else {
+        throw new InternalServerErrorException(`cannot check existence of analysis '${analysisId}'`, { cause: err });
+    }
+}
+
 /**
  * Bundles API endpoints related to message subscriptions.
  */
-@Controller('messages')
+@Controller('analyses/:id/messages')
 @UseGuards(AuthGuard)
 export class MessageSubscriptionController {
     private readonly subscriptionService: MessageSubscriptionService;
 
-    constructor(subscriptionService: MessageSubscriptionService) {
+    private readonly hubApiClient: APIClient;
+
+    constructor(subscriptionService: MessageSubscriptionService, hubApiClient: APIClient) {
         this.subscriptionService = subscriptionService;
+        this.hubApiClient = hubApiClient;
     }
 
     @Post('subscriptions')
     @HttpCode(201)
-    async subscribe(@Body() data: AddSubscriptionRequestBody, @Req() req: Request, @Res() res: Response) {
-        const { id } = await this.subscriptionService.addSubscription({
-            analysisId: data.analysisId,
-            webhookUrl: data.webhookUrl,
-        });
-        const subscriptionResourceLocation = `${req.protocol}://${req.get('Host')}${req.originalUrl}/${id}`;
-        res.header('Location', subscriptionResourceLocation);
-        res.json({
-            subscriptionId: id,
-        });
+    async subscribe(@Param('id') analysisId: string, @Body() data: AddSubscriptionRequestBody, @Req() req: Request, @Res() res: Response) {
+        return this.hubApiClient.analysis.getOne(analysisId)
+            .catch((err) => handleHubApiError(err, analysisId))
+            .then(() => this.subscriptionService.addSubscription({
+                analysisId,
+                webhookUrl: data.webhookUrl,
+            }))
+            .catch((err) => {
+                if (err instanceof HttpException) {
+                    throw err;
+                } else {
+                    throw new InternalServerErrorException(`cannot save subscription for analysis '${analysisId}'`, { cause: err });
+                }
+            })
+            .then(({ id }) => {
+                const subscriptionResourceLocation = `${req.protocol}://${req.get('Host')}${req.originalUrl}/${id}`;
+                res.header('Location', subscriptionResourceLocation);
+                res.json({
+                    subscriptionId: id,
+                });
+            });
     }
 
     @Get('subscriptions/:id')

--- a/src/server/message/subscription/subscription.module.ts
+++ b/src/server/message/subscription/subscription.module.ts
@@ -1,5 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import { APIClient } from '@privateaim/core';
+import { ConfigService } from '@nestjs/config';
+import type { ClientResponseErrorTokenHookOptions } from '@authup/core';
+import { mountClientResponseErrorTokenHook } from '@authup/core';
 import { SubscriptionSchema } from './persistence/subscription.schema';
 import { MessageSubscriptionService } from './subscription.service';
 import { MessageSubscriptionController } from './subscription.controller';
@@ -10,7 +14,30 @@ import { MessageSubscriptionController } from './subscription.controller';
 @Module({
     imports: [MongooseModule.forFeature([{ name: 'subscription', schema: SubscriptionSchema }])],
     controllers: [MessageSubscriptionController],
-    providers: [MessageSubscriptionService],
+    providers: [
+        {
+            provide: APIClient,
+            useFactory: async (configService: ConfigService) => {
+                const hookOptions: ClientResponseErrorTokenHookOptions = {
+                    baseURL: configService.getOrThrow<string>('hub.auth.baseUrl'),
+                    tokenCreator: {
+                        type: 'robot',
+                        id: configService.getOrThrow<string>('hub.auth.robotId'),
+                        secret: configService.getOrThrow<string>('hub.auth.robotSecret'),
+                    },
+                };
+
+                const hubClient = new APIClient({
+                    baseURL: configService.get<string>('hub.baseUrl'),
+                });
+                mountClientResponseErrorTokenHook(hubClient, hookOptions);
+
+                return hubClient;
+            },
+            inject: [ConfigService],
+        },
+        MessageSubscriptionService,
+    ],
     exports: [MessageSubscriptionService],
 })
 export class MessageSubscriptionModule { }


### PR DESCRIPTION
Resolves #71.

Adjusts the endpoint used for message subscriptions. Bases it off of an analysis which moves the analysis identifier from the request body to the actual URL.
This has been done to put an emphasis on the fact that subscriptions for messages are grouped by an analysis identifier.

Also adds existence checks before adding a message subscription. When an analysis does not exist on the central side (hub) then the client must not be able to add a message subscription.
This is done because there won't be any incoming messages if for an analysis if it does not exist in the first place.