### PR TITLE
Fix/Reference Valid Artifact in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY --chown=node:node ./dist .
 
 EXPOSE 3000
 
-CMD [ "node", "index.js" ]
+CMD [ "node", "index.cjs" ]


### PR DESCRIPTION
Fixes #79.

Adjusts the artifact that is being referenced by the Dockerfile. Uses an .cjs file since the message broker is using nestjs which itself makes use of express. The latter being a CommonJS module. To avoid any JS shenanigans when it comes to correctly importing dependencies it was decided to go with the .cjs file.