### PR TITLE
fix: set type info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "type": "git",
         "url": "https://github.com/PrivateAIM/node-message-broker.git"
     },
+    "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Resolves #118.

Sets the type information to module in order to
enable usage of the import syntax.