### PR TITLE
Load Additional Trusted Certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ k8s/tmp**
 cert-showcase/config/secrets
 !cert-showcase/config/secrets/.gitkeep
 cert-showcase/config/**/*.pem
-cert-showcase/truststore-with-added-certs
 
 # SYSTEM TESTS
 system-tests/**/*.pem

--- a/README.MD
+++ b/README.MD
@@ -27,22 +27,24 @@ releases. For the time being use your own instance or a public one._
 This application requires [Maven](https://maven.apache.org) and at least Java 21 to run. Use the following environment
 variables to adjust the application to your needs:
 
-| EnvVar                              | Description                                                                                    | Default         |
-|-------------------------------------|------------------------------------------------------------------------------------------------|-----------------|
-| AUTH_JWKS_URL                       | URL to retrieve a JWKS for verifying JWTs.                                                     |                 |
-| HUB_AUTH_BASE_URL                   | Base URL to reach the Hub's core component.                                                    |                 |
-| HUB_AUTH_ROBOT_ID                   | Robot ID associated with the node.                                                             |                 |
-| HUB_AUTH_ROBOT_SECRET_FILE          | Path to the file containing the secret of the node's associated robot account, Base64 encoded. |                 |
-| HUB_BASE_URL                        | Base URL to reach the Hub's auth component.                                                    |                 |
-| HUB_MESSENGER_BASE_URL              | Base URL to reach the Hub's messenger component.                                               |                 |
-| LOG_LEVEL                           | Log level being used. Can be either of `trace`, `debug`, `info`, `warn` or `error`.            | `info`          |
-| MANAGEMENT_SERVER_PORT              | Port being used by the management server (providing health check endpoints etc.)               | `8090`          |
-| PERSISTENCE_DATABASE_NAME           | Database name to use when connecting to a MongoDB instance.                                    | `messagebroker` |
-| PERSISTENCE_HOSTNAME                | Hostname to use to connect to a MongoDB instance.                                              | `localhost`     |
-| PERSISTENCE_PORT                    | Port to use to connect to a MongoDB instance.                                                  | `17017`         |
-| SECURITY_NODE_PRIVATE_ECDH_KEY_FILE | Path to the file containing the node's private EC key in PEM format, Base64 encoded.           |                 |
-| SERVER_PORT                         | Port being used by the Web server.                                                             | `8080`          |
+| EnvVar                                 | Description                                                                                    | Default         |
+|----------------------------------------|------------------------------------------------------------------------------------------------|-----------------|
+| AUTH_JWKS_URL                          | URL to retrieve a JWKS for verifying JWTs.                                                     |                 |
+| HUB_AUTH_BASE_URL                      | Base URL to reach the Hub's core component.                                                    |                 |
+| HUB_AUTH_ROBOT_ID                      | Robot ID associated with the node.                                                             |                 |
+| HUB_AUTH_ROBOT_SECRET_FILE             | Path to the file containing the secret of the node's associated robot account, Base64 encoded. |                 |
+| HUB_BASE_URL                           | Base URL to reach the Hub's auth component.                                                    |                 |
+| HUB_MESSENGER_BASE_URL                 | Base URL to reach the Hub's messenger component.                                               |                 |
+| LOG_LEVEL                              | Log level being used. Can be either of `trace`, `debug`, `info`, `warn` or `error`.            | `info`          |
+| MANAGEMENT_SERVER_PORT                 | Port being used by the management server (providing health check endpoints etc.)               | `8090`          |
+| PERSISTENCE_DATABASE_NAME              | Database name to use when connecting to a MongoDB instance.                                    | `messagebroker` |
+| PERSISTENCE_HOSTNAME                   | Hostname to use to connect to a MongoDB instance.                                              | `localhost`     |
+| PERSISTENCE_PORT                       | Port to use to connect to a MongoDB instance.                                                  | `17017`         |
+| SECURITY_ADDITIONAL_TRUSTED_CERTS_FILE | Path to a certificate bundle containing additional certificates to be loaded during startup.   |                 |
+| SECURITY_NODE_PRIVATE_ECDH_KEY_FILE    | Path to the file containing the node's private EC key in PEM format, Base64 encoded.           |                 |
+| SERVER_PORT                            | Port being used by the Web server.                                                             | `8080`          |
 
 ## Endpoint Documentation
 
-OpenAPI compliant endpoint documentation can be accessed at [http://localhost:<MANAGEMENT_SERVER_PORT>/actuator/swagger-ui](http://localhost:<MANAGEMENT_SERVER_PORT>/actuator/swagger-ui).
+OpenAPI compliant endpoint documentation can be accessed
+at [http://localhost:<MANAGEMENT_SERVER_PORT>/actuator/swagger-ui](http://localhost:<MANAGEMENT_SERVER_PORT>/actuator/swagger-ui).

--- a/cert-showcase/README.md
+++ b/cert-showcase/README.md
@@ -5,15 +5,17 @@ service.
 
 ## Process of adding additional certificates
 
-Since the message broker service is based on an [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin) Java image
-it's inevitable that a Java truststore needs to be used. However, this cannot be altered without root permissions. Thus,
-altering the file within a non-root context is not possible and requires the following workflow instead:
+The message broker is based on an [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin) Java image and internally
+using the [Spring framework](https://spring.io/projects/spring-framework). Both of these have their own variants of
+providing additional certificates. Temurin allows for mounting a custom trust store. However, this requires the use of
+Java's [keytool](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html) which is cumbersome during
+deployment. Spring itself offers providing certificate bundles. However, this approach does not make use of existing
+certificates and thus is also not applicable.
 
-1. Copy the bundled truststore from the used base Docker image to your local system
-2. Alter the copied truststore using a Docker container with `keytool` being installed to import additional certificates
-   being mounted
-3. Mount the altered truststore to the message broker container to `/opt/java/openjdk/lib/security/cacerts` (default
-   truststore)
+Instead, the message broker allows to provide additional certificates by setting the environment variable
+`SECURITY_ADDITIONAL_TRUSTED_CERTS_FILE` to point the application to a certificate bundle file. This certificate bundle
+is loaded during application startup and added to already existing trust material. This composed trust material is then
+used in client implementations for outgoing connections.
 
 ## Test setup
 

--- a/cert-showcase/create-cert.sh
+++ b/cert-showcase/create-cert.sh
@@ -12,17 +12,4 @@ cat privateaim.pem > "$BASE_DIR"/config/self-signed-cert.pem && \
 cat privateaim.pem > "$BASE_DIR"/config/haproxy/self-signed.pem && \
 cat privateaim.key >> "$BASE_DIR"/config/haproxy/self-signed.pem
 
-docker cp $(docker create --name truststore eclipse-temurin:21-jre-alpine@sha256:2a0bbb1db6d8db42c66ed00c43d954cf458066cc37be12b55144781da7864fdf):/opt/java/openjdk/lib/security/cacerts . && docker rm truststore
-
-docker run --name cert-setup \
-  --rm \
-  -v ./cacerts:/tmp/cacerts \
-  -v "$BASE_DIR"/config/self-signed-cert.pem:/tmp/custom-certs/self-signed-cert.pem:ro \
-  --entrypoint=/bin/sh \
-  eclipse-temurin:21-jre-alpine@sha256:2a0bbb1db6d8db42c66ed00c43d954cf458066cc37be12b55144781da7864fdf \
-  -c \
-  'chown 0:0 /tmp/cacerts && /opt/java/openjdk/bin/keytool -import -file /tmp/custom-certs/self-signed-cert.pem -alias privateaim -keystore /tmp/cacerts -trustcacerts -storepass changeit -noprompt'
-
-cp ./cacerts "$BASE_DIR"/truststore-with-added-certs
-
 rm -Rf $TMP_DIR

--- a/cert-showcase/docker-compose.yml
+++ b/cert-showcase/docker-compose.yml
@@ -55,8 +55,8 @@ services:
     #    read_only: true
     #    type: bind
     volumes:
-      - source: ./truststore-with-added-certs
-        target: /opt/java/openjdk/lib/security/cacerts
+      - source: ./config/self-signed-cert.pem
+        target: /opt/certs/self-signed-cert.pem
         read_only: true
         type: bind
     environment:
@@ -71,6 +71,7 @@ services:
       PERSISTENCE_HOSTNAME: "node-db"
       PERSISTENCE_PORT: 27017
       PERSISTENCE_DATABASE_NAME: "node-message-broker"
+      SECURITY_ADDITIONAL_TRUSTED_CERTS_FILE: "/opt/certs/self-signed-cert.pem"
       # See comment up top for a reason why this is not working!
       #USE_SYSTEM_CA_CERTS: 1 # this is specific to the used eclipse temurin image!
 

--- a/src/main/java/de/privateaim/node_message_broker/common/CommonSpringConfig.java
+++ b/src/main/java/de/privateaim/node_message_broker/common/CommonSpringConfig.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
@@ -50,7 +51,8 @@ public class CommonSpringConfig {
     @Qualifier("HUB_CORE_WEB_CLIENT")
     @Bean
     public WebClient alwaysReAuthenticatedWebClient(
-            @Qualifier("HUB_AUTH_RENEW_TOKEN") ExchangeFilterFunction renewTokenFilter) {
+            @Qualifier("HUB_AUTH_RENEW_TOKEN") ExchangeFilterFunction renewTokenFilter,
+            @Qualifier("BASE_SSL_HTTP_CLIENT_CONNECTOR") ReactorClientHttpConnector baseSslHttpClientConnector) {
         // We can't use Spring's default security mechanisms out-of-the-box here since HUB uses a non-standard grant
         // type which is not supported. There's a way by using a custom grant type accompanied by a client manager.
         // However, this endeavour is not pursued for the sake of simplicity.
@@ -64,6 +66,7 @@ public class CommonSpringConfig {
                 .uriBuilderFactory(factory)
                 .defaultHeaders(httpHeaders -> httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON)))
                 .filter(renewTokenFilter)
+                .clientConnector(baseSslHttpClientConnector)
                 .build();
     }
 
@@ -79,10 +82,12 @@ public class CommonSpringConfig {
 
     @Qualifier("HUB_AUTH_WEB_CLIENT")
     @Bean
-    WebClient hubAuthWebClient() {
+    WebClient hubAuthWebClient(
+            @Qualifier("BASE_SSL_HTTP_CLIENT_CONNECTOR") ReactorClientHttpConnector baseSslHttpClientConnector) {
         return WebClient.builder()
                 .baseUrl(hubAuthBaseUrl)
                 .defaultHeaders(httpHeaders -> httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON)))
+                .clientConnector(baseSslHttpClientConnector)
                 .build();
     }
 

--- a/src/main/java/de/privateaim/node_message_broker/common/CommonSslSpringConfig.java
+++ b/src/main/java/de/privateaim/node_message_broker/common/CommonSslSpringConfig.java
@@ -1,0 +1,179 @@
+package de.privateaim.node_message_broker.common;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import reactor.netty.http.client.HttpClient;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * Configuration parts for SSL functionality.
+ */
+@Slf4j
+@Configuration
+public class CommonSslSpringConfig {
+
+    // Taken from: https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#trustmanagerfactory-algorithms
+    private static final String TRUST_MANAGER_FACTORY_ALGORITHM = "PKIX";
+    private static final String DEFAULT_TRUSTSTORE_PASSWORD = "changeit";
+    private static final String TRUST_STORE_PROPERTY = "javax.net.ssl.trustStore";
+    private static final String TRUST_STORE_PASSWORD_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String JAVA_HOME_PROPERTY = "java.home";
+    private static final String CERTIFICATE_FACTORY_TYPE = "X.509";
+    private static final String SSL_CONTEXT_PROTOCOL = "TLS";
+
+    @Value("${app.security.additionalTrustedCertsFile}")
+    private String additionalTrustedCertsFile;
+
+    @Qualifier("BASE_SSL_HTTP_CLIENT_CONNECTOR")
+    @Bean
+    ReactorClientHttpConnector baseHttpClientConnector(@Qualifier("COMMON_NETTY_SSL_CONTEXT") SslContext sslContext) {
+        return new ReactorClientHttpConnector(
+                HttpClient
+                        .create()
+                        .secure(t -> t.sslContext(sslContext)));
+    }
+
+    @Qualifier("COMMON_NETTY_SSL_CONTEXT")
+    @Bean
+    SslContext sslContextNetty(@Qualifier("COMMON_TRUST_MANAGER_FACTORY") TrustManagerFactory tmf) throws IOException {
+        return SslContextBuilder.forClient()
+                .trustManager(tmf)
+                .build();
+    }
+
+    @Qualifier("COMMON_JAVA_SSL_CONTEXT")
+    @Bean
+    SSLContext sslContextJava(@Qualifier("COMMON_TRUST_MANAGER_FACTORY") TrustManagerFactory tmf) {
+        try {
+            var ctx = SSLContext.getInstance(SSL_CONTEXT_PROTOCOL);
+            ctx.init(null, tmf.getTrustManagers(), null);
+
+            return ctx;
+        } catch (NoSuchAlgorithmException e) {
+            // cannot happen
+            throw new RuntimeException(e);
+        } catch (KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Qualifier("COMMON_TRUST_MANAGER_FACTORY")
+    @Bean
+    TrustManagerFactory sharedTrustManagerFactory() throws IOException, KeyStoreException {
+        var additionalCerts = loadAdditionalCerts();
+        return getTrustManagerFactory(additionalCerts);
+    }
+
+    private TrustManagerFactory getTrustManagerFactory(List<X509Certificate> additionalCerts) throws IOException,
+            KeyStoreException {
+        var trustStore = System.getProperty(TRUST_STORE_PROPERTY);
+
+        var ks = (trustStore != null && !trustStore.isEmpty())
+                ? loadKeyStore(new File(trustStore), getTrustStorePassword())
+                : loadDefaultKeyStore();
+
+        for (X509Certificate cert : additionalCerts) {
+            ks.setCertificateEntry(cert.getSubjectX500Principal().getName(), cert);
+        }
+
+        try {
+            var tmf = TrustManagerFactory.getInstance(TRUST_MANAGER_FACTORY_ALGORITHM);
+            tmf.init(ks);
+            return tmf;
+        } catch (NoSuchAlgorithmException e) {
+            // cannot happen because each JRE implementation is supposed to offer the used algorithm
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<X509Certificate> loadAdditionalCerts() {
+        if (additionalTrustedCertsFile == null || additionalTrustedCertsFile.isEmpty()) {
+            log.warn("no additional trusted certificate specified, using only the default trust store");
+            return List.of();
+        }
+
+        log.info("loading additional certificates from bundle file at {}", additionalTrustedCertsFile);
+
+        try {
+            var cf = CertificateFactory.getInstance(CERTIFICATE_FACTORY_TYPE);
+            return cf.generateCertificates(new FileInputStream(additionalTrustedCertsFile))
+                    .stream()
+                    .map(X509Certificate.class::cast)
+                    .toList();
+        } catch (CertificateException e) {
+            // cannot happen because each JRE implementation is supposed to offer the used type
+            throw new RuntimeException(e);
+        } catch (FileNotFoundException e) {
+            log.error("additional certificates bundle file at `{}` does not exist", additionalTrustedCertsFile);
+            throw new RuntimeException("additional certificates bundle file at `%s` does not exist".formatted(
+                    additionalTrustedCertsFile));
+        }
+    }
+
+    private KeyStore loadKeyStore(File keyStoreFile, String keyStorePassword) throws IOException {
+        if (!keyStoreFile.exists()) {
+            throw new IOException("key store at `%s` does not exist".formatted(keyStoreFile.getAbsolutePath()));
+        }
+
+        try (var fis = new FileInputStream(keyStoreFile)) {
+            var keyStore = getBlankKeyStore();
+            keyStore.load(fis, keyStorePassword.toCharArray());
+
+            return keyStore;
+        } catch (CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private KeyStore loadDefaultKeyStore() throws IOException {
+        var javaHomeDir = System.getProperty(JAVA_HOME_PROPERTY);
+
+        if (javaHomeDir == null || javaHomeDir.isEmpty()) {
+            throw new RuntimeException("Java home directory could not be found");
+        }
+
+        var keyStorePath = Paths.get(javaHomeDir, "lib", "security", "cacerts");
+        var keyStorePassword = getTrustStorePassword();
+
+        return loadKeyStore(new File(keyStorePath.toString()), keyStorePassword);
+    }
+
+    private String getTrustStorePassword() {
+        var trustStorePassword = System.getProperty(TRUST_STORE_PASSWORD_PROPERTY);
+        if (trustStorePassword == null || trustStorePassword.isEmpty()) {
+            return DEFAULT_TRUSTSTORE_PASSWORD; // default keystore password
+        } else {
+            return trustStorePassword;
+        }
+    }
+
+    private KeyStore getBlankKeyStore() {
+        try {
+            return KeyStore.getInstance(KeyStore.getDefaultType());
+        } catch (KeyStoreException e) {
+            // cannot happen, since the used algorithm needs to be provided by EVERY JRE implementation
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,4 @@ app:
       baseUrl: ${HUB_MESSENGER_BASE_URL}
   security:
     nodePrivateECDHKeyFile: ${SECURITY_NODE_PRIVATE_ECDH_KEY_FILE}
+    additionalTrustedCertsFile: ${SECURITY_ADDITIONAL_TRUSTED_CERTS_FILE:}


### PR DESCRIPTION
Dynamically loads additional trusted certificates from a bundle file and adds them to the SSL context being used for outgoing connections.
This also covers the Socket.IO connection being used to connect to the Hub's messenger service.

Resolves #247