### PR TITLE
Increase HTTP Client Timeout

### DIFF
--- a/system-tests/tests/message-broker/auth.go
+++ b/system-tests/tests/message-broker/auth.go
@@ -24,7 +24,7 @@ type messageBrokerAuthClient struct {
 func NewMessageBrokerAuthClient(baseUrl string, clientId string, clientSecret string) MessageBrokerAuthClient {
 	return &messageBrokerAuthClient{
 		baseUrl:      baseUrl,
-		httpClient:   http.Client{Timeout: time.Duration(1) * time.Second},
+		httpClient:   http.Client{Timeout: time.Duration(300) * time.Second},
 		clientId:     clientId,
 		clientSecret: clientSecret,
 	}

--- a/system-tests/tests/message-broker/client.go
+++ b/system-tests/tests/message-broker/client.go
@@ -51,6 +51,6 @@ func NewMessageBrokerClient(baseUrl string, managementBaseUrl string, accessToke
 		baseUrl:             baseUrl,
 		managementBaseUrl:   managementBaseUrl,
 		accessTokenAcquirer: accessTokenAcquirer,
-		httpClient:          http.Client{Timeout: time.Duration(1) * time.Second},
+		httpClient:          http.Client{Timeout: time.Duration(300) * time.Second},
 	}
 }


### PR DESCRIPTION
The previously used timeout is not big enough
for scenarios where the executing machine is
suffering from high resource utilization.
Thus, the timeout has been increased to 5
minutes.

Fixes #258 