### PR TITLE
Revise Handling of NodeID / RobotID

### DIFF
--- a/src/main/java/de/privateaim/node_message_broker/discovery/DiscoveryController.java
+++ b/src/main/java/de/privateaim/node_message_broker/discovery/DiscoveryController.java
@@ -37,7 +37,7 @@ public final class DiscoveryController {
         return discoveryService.discoverAllParticipantsOfAnalysis(analysisId)
                 .collectList()
                 .map(participants -> participants.stream()
-                        .map(p -> new ParticipantResponse(p.nodeRobotId(), p.nodeType()))
+                        .map(p -> new ParticipantResponse(p.nodeId(), p.nodeType()))
                         .toList())
                 .map(ResponseEntity::ok)
                 .onErrorMap(AnalysisNodesLookupException.class, err ->
@@ -51,7 +51,7 @@ public final class DiscoveryController {
         }
 
         return discoveryService.discoverSelfInAnalysis(analysisId)
-                .map(p -> new ParticipantResponse(p.nodeRobotId(), p.nodeType()))
+                .map(p -> new ParticipantResponse(p.nodeId(), p.nodeType()))
                 .map(ResponseEntity::ok)
                 .onErrorMap(AnalysisNodesLookupException.class, err ->
                         new ResponseStatusException(HttpStatus.BAD_GATEWAY, err.getMessage(), err))

--- a/src/main/java/de/privateaim/node_message_broker/discovery/DiscoveryService.java
+++ b/src/main/java/de/privateaim/node_message_broker/discovery/DiscoveryService.java
@@ -35,7 +35,7 @@ public final class DiscoveryService {
      * identifier.
      *
      * @param analysisId unique identifier of the analysis whose participating nodes shall get discovered
-     * @return All participants of the analysis if there are any.s
+     * @return All participants of the analysis if there are any.
      */
     Flux<Participant> discoverAllParticipantsOfAnalysis(@NotNull String analysisId) {
         if (analysisId == null) {
@@ -50,6 +50,7 @@ public final class DiscoveryService {
                         "analysis nodes", err))
                 .flatMapIterable(analysisNodes -> analysisNodes.stream()
                         .map(analysisNode -> new Participant(
+                                analysisNode.node.id,
                                 analysisNode.node.robotId,
                                 ParticipantType.fromRepresentation(analysisNode.node.type)
                         )).toList())
@@ -77,7 +78,7 @@ public final class DiscoveryService {
                 .collectList()
                 .flatMap(participants -> {
                     var selfParticipants = participants.stream()
-                            .filter(p -> p.nodeRobotId().equals(selfRobotId))
+                            .filter(p -> p.robotId().equals(selfRobotId))
                             .toList();
 
                     if (selfParticipants.isEmpty()) {

--- a/src/main/java/de/privateaim/node_message_broker/discovery/Participant.java
+++ b/src/main/java/de/privateaim/node_message_broker/discovery/Participant.java
@@ -5,11 +5,13 @@ import de.privateaim.node_message_broker.discovery.api.ParticipantType;
 /**
  * Represents a participant in its internal form.
  *
- * @param nodeRobotId unique identifier of a node's robot account associated with it
- * @param nodeType    type of the node (default | aggregator)
+ * @param nodeId   unique identifier of a node
+ * @param robotId  unique identifier of a node's robot account (used for internal communications & authentication)
+ * @param nodeType type of the node (default | aggregator)
  */
 public record Participant(
-        String nodeRobotId,
+        String nodeId,
+        String robotId,
         ParticipantType nodeType
 ) {
 }

--- a/src/test/java/de/privateaim/node_message_broker/discovery/DiscoveryControllerIT.java
+++ b/src/test/java/de/privateaim/node_message_broker/discovery/DiscoveryControllerIT.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.publisher.Flux;
@@ -30,7 +30,7 @@ public final class DiscoveryControllerIT {
     private static final String ANALYSIS_ID = "ana-123";
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    @MockBean
+    @MockitoBean
     private DiscoveryService mockedDiscoveryService;
 
     private WebTestClient client;
@@ -96,8 +96,8 @@ public final class DiscoveryControllerIT {
         @Test
         void returns200WithAllDiscoveredParticipants() throws IOException {
             var participants = List.of(
-                    new Participant("123", ParticipantType.AGGREGATOR),
-                    new Participant("456", ParticipantType.DEFAULT)
+                    new Participant("123", "abc", ParticipantType.AGGREGATOR),
+                    new Participant("456", "def", ParticipantType.DEFAULT)
             );
             Mockito.doReturn(Flux.fromIterable(participants))
                     .when(mockedDiscoveryService)
@@ -113,9 +113,9 @@ public final class DiscoveryControllerIT {
 
             assertEquals(participants.size(), clientReceivedParticipants.size());
             assertEquals(participants.getFirst().nodeType(), clientReceivedParticipants.getFirst().getNodeType());
-            assertEquals(participants.getFirst().nodeRobotId(), clientReceivedParticipants.getFirst().nodeId);
+            assertEquals(participants.getFirst().nodeId(), clientReceivedParticipants.getFirst().nodeId);
             assertEquals(participants.getLast().nodeType(), clientReceivedParticipants.getLast().getNodeType());
-            assertEquals(participants.getLast().nodeRobotId(), clientReceivedParticipants.getLast().nodeId);
+            assertEquals(participants.getLast().nodeId(), clientReceivedParticipants.getLast().nodeId);
         }
     }
 
@@ -164,7 +164,7 @@ public final class DiscoveryControllerIT {
 
         @Test
         void returns200WithTheDiscoveredSelfNode() throws IOException {
-            var self = new Participant("robot-123", ParticipantType.AGGREGATOR);
+            var self = new Participant("node-123", "robot-123", ParticipantType.AGGREGATOR);
             Mockito.doReturn(Mono.just(self))
                     .when(mockedDiscoveryService)
                     .discoverSelfInAnalysis(ANALYSIS_ID);
@@ -178,7 +178,7 @@ public final class DiscoveryControllerIT {
 
             assertNotNull(clientReceivedSelf);
             assertEquals(self.nodeType(), clientReceivedSelf.getNodeType());
-            assertEquals(self.nodeRobotId(), clientReceivedSelf.getNodeId());
+            assertEquals(self.nodeId(), clientReceivedSelf.getNodeId());
         }
     }
 }

--- a/src/test/java/de/privateaim/node_message_broker/discovery/DiscoveryServiceIT.java
+++ b/src/test/java/de/privateaim/node_message_broker/discovery/DiscoveryServiceIT.java
@@ -77,12 +77,12 @@ public final class DiscoveryServiceIT {
             assertEquals(participatingAnalysisNodes.size(), discoveredParticipants.size());
             assertEquals(participatingAnalysisNodes.getFirst().node.type,
                     discoveredParticipants.getFirst().nodeType().getRepresentation());
-            assertEquals(participatingAnalysisNodes.getFirst().node.robotId,
-                    discoveredParticipants.getFirst().nodeRobotId());
+            assertEquals(participatingAnalysisNodes.getFirst().node.id,
+                    discoveredParticipants.getFirst().nodeId());
             assertEquals(participatingAnalysisNodes.getLast().node.type,
                     discoveredParticipants.getLast().nodeType().getRepresentation());
-            assertEquals(participatingAnalysisNodes.getLast().node.robotId,
-                    discoveredParticipants.getLast().nodeRobotId());
+            assertEquals(participatingAnalysisNodes.getLast().node.id,
+                    discoveredParticipants.getLast().nodeId());
         }
 
         @Test
@@ -154,7 +154,7 @@ public final class DiscoveryServiceIT {
                     .setBody(JSON.writeValueAsString(mockedHubResponse)));
 
             StepVerifier.create(discoveryService.discoverSelfInAnalysis(ANALYSIS_ID))
-                    .expectNext(new Participant(SELF_ROBOT_ID, ParticipantType.AGGREGATOR))
+                    .expectNext(new Participant("node-1", SELF_ROBOT_ID, ParticipantType.AGGREGATOR))
                     .verifyComplete();
         }
     }

--- a/src/test/java/de/privateaim/node_message_broker/message/MessageServiceIT.java
+++ b/src/test/java/de/privateaim/node_message_broker/message/MessageServiceIT.java
@@ -98,7 +98,7 @@ public final class MessageServiceIT {
                     .setBody(JSON.writeValueAsString(mockedHubResponse)));
 
             var messageRequest = new MessageRequest();
-            messageRequest.recipients = List.of("robot-not-in-list");
+            messageRequest.recipients = List.of("node-not-in-list");
             messageRequest.message = JsonNodeFactory.instance.objectNode();
 
             StepVerifier.create(messageService.sendMessageToSelectedRecipients("123", messageRequest))
@@ -115,7 +115,7 @@ public final class MessageServiceIT {
             var mockedHubResponse = new HubResponseContainer<>(testAnalysisNodes);
 
             var messageRequest = new MessageRequest();
-            messageRequest.recipients = List.of("robot-1", "robot-2");
+            messageRequest.recipients = List.of("node-1", "node-2");
             messageRequest.message = JsonNodeFactory.instance.objectNode();
 
             mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.SC_OK)
@@ -143,7 +143,7 @@ public final class MessageServiceIT {
             var mockedHubResponse = new HubResponseContainer<>(testAnalysisNodes);
 
             var messageRequest = new MessageRequest();
-            messageRequest.recipients = List.of("robot-1", "robot-2", "robot-3");
+            messageRequest.recipients = List.of("node-1", "node-2", "node-3");
             messageRequest.message = JsonNodeFactory.instance.objectNode();
 
             mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.SC_OK)
@@ -172,7 +172,7 @@ public final class MessageServiceIT {
             var mockedHubResponse = new HubResponseContainer<>(testAnalysisNodes);
 
             var messageRequest = new MessageRequest();
-            messageRequest.recipients = List.of("robot-1", "robot-2", SELF_ROBOT_ID);
+            messageRequest.recipients = List.of("node-1", "node-2", "node-3");
             messageRequest.message = JsonNodeFactory.instance.objectNode();
 
             mockWebServer.enqueue(new MockResponse().setResponseCode(HttpStatus.SC_OK)


### PR DESCRIPTION
Resolves #251.

Opposed to what has been stated in the linked issue, only the `NodeID` is exposed to the client. Everything else is internal information and must not leak. Thus, the change simply exposes the correct information without altering the API (since it was already labeled `nodeId`). When sending message requests this `nodeId` information is going to be mapped to the corresponding `robotId` which is used for internal communications.

This fix does not require any changes to how the application needs to be set up.