### PR TITLE
Enable Usage of Virtual Threads

### DIFF
--- a/src/main/java/de/privateaim/node_message_broker/common/CommonSpringConfig.java
+++ b/src/main/java/de/privateaim/node_message_broker/common/CommonSpringConfig.java
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.VirtualThreadTaskExecutor;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
@@ -128,5 +131,11 @@ public class CommonSpringConfig {
             @Qualifier("HUB_AUTHENTICATOR") OIDCAuthenticator authenticator
     ) {
         return new OIDCAuthenticatorMiddleware(authenticator);
+    }
+
+    @Primary
+    @Bean
+    public TaskExecutor defaultTaskExecutor() {
+        return new VirtualThreadTaskExecutor();
     }
 }


### PR DESCRIPTION
Makes use of virtual threads instead of fat threads to boost performance and reduce the impact of context switches. Also reduces the resource overhead that
comes with using regular fat threads.

Resolves #260 