### PR TITLE
fix!: adapt the Hub client to the FLAME Hub 0.13.0 API

### DIFF
--- a/src/main/java/de/privateaim/node_message_broker/common/hub/HttpHubClient.java
+++ b/src/main/java/de/privateaim/node_message_broker/common/hub/HttpHubClient.java
@@ -44,7 +44,7 @@ public final class HttpHubClient implements HubClient {
         return authenticatedWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/analysis-nodes")
-                        .queryParam("filter[analysis_id]", analysisId)
+                        .queryParam("filter[analysisId]", analysisId)
                         .queryParam("include", "node")
                         .build())
                 .retrieve()
@@ -74,7 +74,7 @@ public final class HttpHubClient implements HubClient {
         return authenticatedWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/nodes")
-                        .queryParam("filter[client_id]", clientId)
+                        .queryParam("filter[clientId]", clientId)
                         .build()
                 )
                 .retrieve()

--- a/src/main/java/de/privateaim/node_message_broker/common/hub/api/AnalysisNode.java
+++ b/src/main/java/de/privateaim/node_message_broker/common/hub/api/AnalysisNode.java
@@ -18,8 +18,8 @@ public final class AnalysisNode {
     @JsonProperty("id")
     public String id;
 
-    @JsonProperty("node_id")
-    public String node_id;
+    @JsonProperty("nodeId")
+    public String nodeId;
 
     @JsonProperty("node")
     public Node node;

--- a/src/main/java/de/privateaim/node_message_broker/common/hub/api/Node.java
+++ b/src/main/java/de/privateaim/node_message_broker/common/hub/api/Node.java
@@ -21,9 +21,9 @@ public final class Node {
     @JsonProperty("type")
     public String type;
 
-    @JsonProperty("public_key")
+    @JsonProperty("publicKey")
     public String publicKey;
 
-    @JsonProperty("client_id")
+    @JsonProperty("clientId")
     public String clientId;
 }

--- a/src/test/java/de/privateaim/node_message_broker/common/hub/HttpHubClientIT.java
+++ b/src/test/java/de/privateaim/node_message_broker/common/hub/HttpHubClientIT.java
@@ -99,7 +99,7 @@ public class HttpHubClientIT {
 
                 assertNotNull(requestUrl);
                 assertNotNull(recordedRequest.getPath());
-                assertEquals(ANALYSIS_ID, requestUrl.queryParameter("filter[analysis_id]"));
+                assertEquals(ANALYSIS_ID, requestUrl.queryParameter("filter[analysisId]"));
                 assertEquals("node", requestUrl.queryParameter("include"));
                 assertEquals("/analysis-nodes", URI.create(recordedRequest.getPath()).getPath());
             }
@@ -120,7 +120,7 @@ public class HttpHubClientIT {
 
                 assertNotNull(requestUrl);
                 assertNotNull(recordedRequest.getPath());
-                assertEquals(ANALYSIS_ID, requestUrl.queryParameter("filter[analysis_id]"));
+                assertEquals(ANALYSIS_ID, requestUrl.queryParameter("filter[analysisId]"));
                 assertEquals("node", requestUrl.queryParameter("include"));
                 assertEquals("/analysis-nodes", URI.create(recordedRequest.getPath()).getPath());
             }
@@ -266,7 +266,7 @@ public class HttpHubClientIT {
 
                 assertNotNull(requestUrl);
                 assertNotNull(recordedRequest.getPath());
-                assertEquals(CLIENT_ID, requestUrl.queryParameter("filter[client_id]"));
+                assertEquals(CLIENT_ID, requestUrl.queryParameter("filter[clientId]"));
                 assertEquals("/nodes", URI.create(recordedRequest.getPath()).getPath());
             }
         }
@@ -286,7 +286,7 @@ public class HttpHubClientIT {
 
                 assertNotNull(requestUrl);
                 assertNotNull(recordedRequest.getPath());
-                assertEquals(CLIENT_ID, requestUrl.queryParameter("filter[client_id]"));
+                assertEquals(CLIENT_ID, requestUrl.queryParameter("filter[clientId]"));
                 assertEquals("/nodes", URI.create(recordedRequest.getPath()).getPath());
             }
         }

--- a/system-tests/environment/hub/authup-provisioning.mjs
+++ b/system-tests/environment/hub/authup-provisioning.mjs
@@ -1,0 +1,164 @@
+// FLAME Hub's permission set, declared so Authup can resolve it.
+//
+// Since Hub 0.13.0 the authorization middleware genuinely enforces permissions
+// (it used to run in dry-run mode), and Hub does not register them itself. Each
+// name is declared as a top-level permission so Authup's built-in `admin` role,
+// which holds `globalPermissions: ['*']`, resolves them at provisioning time —
+// which is what puts them in the admin token this suite authenticates with.
+//
+// Mirrors `buildAuthupProvisioning()` in @privateaim/server-test-kit. Keep in
+// sync with `PermissionName` in @privateaim/kit.
+export default {
+    "permissions": [
+        {
+            "attributes": {
+                "name": "event_create"
+            }
+        },
+        {
+            "attributes": {
+                "name": "event_read"
+            }
+        },
+        {
+            "attributes": {
+                "name": "event_delete"
+            }
+        },
+        {
+            "attributes": {
+                "name": "bucket_create"
+            }
+        },
+        {
+            "attributes": {
+                "name": "bucket_update"
+            }
+        },
+        {
+            "attributes": {
+                "name": "bucket_delete"
+            }
+        },
+        {
+            "attributes": {
+                "name": "log_create"
+            }
+        },
+        {
+            "attributes": {
+                "name": "log_delete"
+            }
+        },
+        {
+            "attributes": {
+                "name": "log_read"
+            }
+        },
+        {
+            "attributes": {
+                "name": "project_create"
+            }
+        },
+        {
+            "attributes": {
+                "name": "project_delete"
+            }
+        },
+        {
+            "attributes": {
+                "name": "project_update"
+            }
+        },
+        {
+            "attributes": {
+                "name": "project_approve"
+            }
+        },
+        {
+            "attributes": {
+                "name": "registry_manage"
+            }
+        },
+        {
+            "attributes": {
+                "name": "registry_project_manage"
+            }
+        },
+        {
+            "attributes": {
+                "name": "node_create"
+            }
+        },
+        {
+            "attributes": {
+                "name": "node_delete"
+            }
+        },
+        {
+            "attributes": {
+                "name": "node_update"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_approve"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_update"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_create"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_execution_start"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_execution_stop"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_delete"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_result_read"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_self_message_broker_use"
+            }
+        },
+        {
+            "attributes": {
+                "name": "analysis_self_storage_use"
+            }
+        },
+        {
+            "attributes": {
+                "name": "master_image_manage"
+            }
+        },
+        {
+            "attributes": {
+                "name": "master_image_group_manage"
+            }
+        },
+        {
+            "attributes": {
+                "name": "service_manage"
+            }
+        }
+    ]
+};

--- a/system-tests/environment/hub/hub-docker-compose.yml
+++ b/system-tests/environment/hub/hub-docker-compose.yml
@@ -59,7 +59,7 @@ services:
       hub:
 
   authup:
-    image: authup/authup
+    image: authup/authup:1.0.0-beta.57
     restart: always
     depends_on:
       mysql:
@@ -84,13 +84,15 @@ services:
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-localhost}
       AUTHORIZE_REDIRECT_URL: ${PUBLIC_URL:-http://localhost:3001/}
       ROBOT_ADMIN_ENABLED: true
+    volumes:
+      - ./authup-provisioning.mjs:/usr/src/app/writable/provisioning/hub.mjs:ro
     networks:
       hub:
       hub-node-intercomm:
         ipv4_address: 172.99.20.11
 
   core:
-    image: ghcr.io/privateaim/hub:0.8.31
+    image: ghcr.io/privateaim/hub:0.13.0
     restart: always
     depends_on:
       authup:
@@ -110,7 +112,6 @@ services:
       VAULT_CONNECTION_STRING: start123@http://vault:8090/v1/
       RABBITMQ_CONNECTION_STRING: ${MQ_CONNECTION_URL:-amqp://root:start123@mq:5672}
       PUBLIC_URL: ${CORE_PUBLIC_URL:-http://localhost:3000/}
-      HARBOR_URL: ${HARBOR_URL:-}
       AUTHUP_URL: http://authup:3000/
       CLIENT_ID: 'system'
       CLIENT_SECRET: 'start123'
@@ -129,7 +130,7 @@ services:
         ipv4_address: 172.99.20.10
 
   messenger:
-    image: ghcr.io/privateaim/hub:0.8.31
+    image: ghcr.io/privateaim/hub:0.13.0
     restart: always
     command: messenger cli start
     ports:

--- a/system-tests/environment/hub/hub-docker-compose.yml
+++ b/system-tests/environment/hub/hub-docker-compose.yml
@@ -138,6 +138,8 @@ services:
     depends_on:
       authup:
         condition: service_healthy
+      mysql:
+        condition: service_healthy
       redis:
         condition: service_healthy
       vault:
@@ -146,6 +148,14 @@ services:
       REDIS_CONNECTION_STRING: redis://redis
       VAULT_CONNECTION_STRING: start123@http://vault:8090/v1/
       AUTHUP_URL: http://authup:3000/
+      CLIENT_ID: 'system'
+      CLIENT_SECRET: 'start123'
+      REALM: 'master'
+      DB_TYPE: 'mysql'
+      DB_HOST: 'mysql'
+      DB_USERNAME: 'root'
+      DB_PASSWORD: 'start123'
+      DB_DATABASE: 'messenger'
     networks:
       hub:
       hub-node-intercomm:

--- a/system-tests/environment/hub/hub-docker-compose.yml
+++ b/system-tests/environment/hub/hub-docker-compose.yml
@@ -59,7 +59,7 @@ services:
       hub:
 
   authup:
-    image: authup/authup:1.0.0-beta.57
+    image: authup/authup:1.0.0-beta.58
     restart: always
     depends_on:
       mysql:

--- a/system-tests/environment/resources/hub/analysis-node-setup-template.json
+++ b/system-tests/environment/resources/hub/analysis-node-setup-template.json
@@ -1,8 +1,8 @@
 {
-    "approval_status": "approved",
+    "approvalStatus": "approved",
     "index": 0,
-    "analysis_id": "<ANALYSIS_ID>",
-    "analysis_realm_id": "<REALM_ID>",
-    "node_id": "<NODE_ID>",
-    "node_realm_id": "<REALM_ID>"
+    "analysisId": "<ANALYSIS_ID>",
+    "analysisRealmId": "<REALM_ID>",
+    "nodeId": "<NODE_ID>",
+    "nodeRealmId": "<REALM_ID>"
 }

--- a/system-tests/environment/resources/hub/analysis-setup-template.json
+++ b/system-tests/environment/resources/hub/analysis-setup-template.json
@@ -1,6 +1,6 @@
 {
     "name": "<ANALYSIS_NAME>",
-    "realm_id": "<REALM_ID>",
-    "user_id": "<USER_ID>",
-    "project_id": "<PROJECT_ID>"
+    "realmId": "<REALM_ID>",
+    "userId": "<USER_ID>",
+    "projectId": "<PROJECT_ID>"
 }

--- a/system-tests/environment/resources/hub/client-account-setup-template.json
+++ b/system-tests/environment/resources/hub/client-account-setup-template.json
@@ -4,5 +4,6 @@
     "active": true,
     "realmId": "<REALM_ID>",
     "secretHashed": false,
-    "isConfidential": true
+    "authMethod": "secret",
+    "grantTypes": "client_credentials"
 }

--- a/system-tests/environment/resources/hub/client-account-setup-template.json
+++ b/system-tests/environment/resources/hub/client-account-setup-template.json
@@ -2,7 +2,7 @@
     "secret": "<CLIENT_SECRET>",
     "name": "<CLIENT_NAME>",
     "active": true,
-    "realm_id": "<REALM_ID>",
-    "secret_hashed": false,
-    "is_confidential": true
+    "realmId": "<REALM_ID>",
+    "secretHashed": false,
+    "isConfidential": true
 }

--- a/system-tests/environment/resources/hub/node-setup-template.json
+++ b/system-tests/environment/resources/hub/node-setup-template.json
@@ -2,7 +2,7 @@
     "name": "<NODE_NAME>",
     "hidden": true,
     "type": "default",
-    "client_id": "<CLIENT_ID>",
-    "realm_id": "<REALM_ID>",
-    "public_key": "<PUBLIC_KEY>"
+    "clientId": "<CLIENT_ID>",
+    "realmId": "<REALM_ID>",
+    "publicKey": "<PUBLIC_KEY>"
 }

--- a/system-tests/environment/resources/hub/project-node-setup-template.json
+++ b/system-tests/environment/resources/hub/project-node-setup-template.json
@@ -1,7 +1,7 @@
 {
-    "approval_status": "approved",
-    "project_id": "<PROJECT_ID>",
-    "project_realm_id": "<REALM_ID>",
-    "node_id": "<NODE_ID>",
-    "node_realm_id": "<REALM_ID>"
+    "approvalStatus": "approved",
+    "projectId": "<PROJECT_ID>",
+    "projectRealmId": "<REALM_ID>",
+    "nodeId": "<NODE_ID>",
+    "nodeRealmId": "<REALM_ID>"
 }

--- a/system-tests/environment/resources/hub/project-setup-template.json
+++ b/system-tests/environment/resources/hub/project-setup-template.json
@@ -1,5 +1,5 @@
 {
     "name": "<PROJECT_NAME>",
-    "realm_id": "<REALM_ID>",
-    "user_id": "<USER_ID>"
+    "realmId": "<REALM_ID>",
+    "userId": "<USER_ID>"
 }

--- a/system-tests/environment/resources/hub/setup-hub-resources.sh
+++ b/system-tests/environment/resources/hub/setup-hub-resources.sh
@@ -61,7 +61,7 @@ MASTER_REALM_ID=$(curl -s -G --fail-with-body \
     -H "Accept: application/json" \
     --data-urlencode "filter[name]=${MASTER_REALM_NAME}" \
     -X GET "${HUB_AUTH_BASE_URL}/realms" |\
-    jq -r '.data[0].id')
+    jq -r '.data[0].id // empty')
 if [ -z "${MASTER_REALM_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -76,7 +76,7 @@ ADMIN_USER_ID=$(curl -s -G --fail-with-body \
     -H "Accept: application/json" \
     --data-urlencode "filter[name]=${ADMIN_USER_NAME}" \
     -X GET "${HUB_AUTH_BASE_URL}/users" |\
-    jq -r '.data[0].id')
+    jq -r '.data[0].id // empty')
 if [ -z "${ADMIN_USER_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -107,7 +107,7 @@ CLIENT_A_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${CLIENT_A_SETUP}" \
     -X POST "${HUB_AUTH_BASE_URL}/clients" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${CLIENT_A_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -121,7 +121,7 @@ CLIENT_B_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${CLIENT_B_SETUP}" \
     -X POST "${HUB_AUTH_BASE_URL}/clients" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${CLIENT_B_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -135,7 +135,7 @@ CLIENT_C_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${CLIENT_C_SETUP}" \
     -X POST "${HUB_AUTH_BASE_URL}/clients" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${CLIENT_C_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -159,7 +159,7 @@ PROJECT_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${PROJECT_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/projects" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${PROJECT_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -183,7 +183,7 @@ ANALYSIS_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${ANALYSIS_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/analyses" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${ANALYSIS_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -218,7 +218,7 @@ NODE_A_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${NODE_A_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${NODE_A_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -232,7 +232,7 @@ NODE_B_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${NODE_B_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${NODE_B_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -246,7 +246,7 @@ NODE_C_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${NODE_C_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${NODE_C_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -280,7 +280,7 @@ PROJECT_NODE_A_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${PROJECT_NODE_A_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/project-nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${PROJECT_NODE_A_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -294,7 +294,7 @@ PROJECT_NODE_B_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${PROJECT_NODE_B_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/project-nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${PROJECT_NODE_B_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -308,7 +308,7 @@ PROJECT_NODE_C_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${PROJECT_NODE_C_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/project-nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${PROJECT_NODE_C_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -342,7 +342,7 @@ ANALYSIS_NODE_A_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${ANALYSIS_NODE_A_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/analysis-nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${ANALYSIS_NODE_A_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -356,7 +356,7 @@ ANALYSIS_NODE_B_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${ANALYSIS_NODE_B_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/analysis-nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${ANALYSIS_NODE_B_ID}" ]; then
     echo "FAILED"
     exit 1
@@ -370,7 +370,7 @@ ANALYSIS_NODE_C_ID=$(curl -s --fail-with-body \
     -H "Content-Type: application/json" \
     -d "${ANALYSIS_NODE_C_SETUP}" \
     -X POST "${HUB_API_BASE_URL}/analysis-nodes" |\
-    jq -r '.id')
+    jq -r '.data.id // empty')
 if [ -z "${ANALYSIS_NODE_C_ID}" ]; then
     echo "FAILED"
     exit 1


### PR DESCRIPTION
FLAME Hub 0.13.0 landed two breaking changes together:

- [PrivateAIM/hub#1806](https://github.com/PrivateAIM/hub/pull/1806) — `snake_case` → `camelCase` across every entity, HTTP field and rapiq query key
- [PrivateAIM/hub#1801](https://github.com/PrivateAIM/hub/pull/1801) — every entity **record** response wrapped in `{ data, meta }`

The broker's Hub surface is small — two `GET`s and two DTOs — but **every one of these failures is silent**. That is the reason for the PR rather than the size of the diff.

## The rapiq filter keys

`HttpHubClient` sent `filter[analysis_id]` and `filter[client_id]`. rapiq **prunes an unknown filter key instead of rejecting it**, so against 0.13.0:

| Call | Behaviour with the stale key | Severity |
|---|---|---|
| `fetchAnalysisNodes` → `GET /analysis-nodes?filter[analysis_id]=…` | filter dropped → responds with **every analysis node the client can see**, not the analysis's. The broker would treat unrelated nodes as participants of the analysis and route messages to them. | confidentiality |
| `fetchPublicKey` → `GET /nodes?filter[client_id]=…` | filter dropped → `resp.data.size() != 1` → `NoMatchingNodeFoundException` as soon as more than one node exists | fails loudly, at least |

No 4xx in either case. The first one looks like success.

## The DTOs

`Node` and `AnalysisNode` are `@JsonIgnoreProperties(ignoreUnknown = true)`, so a stale `@JsonProperty` deserializes to **`null`** rather than throwing:

- `Node.public_key` → `publicKey`. This is the one that matters: a null public key means `NoPublicKeyException` on every send, i.e. **end-to-end encryption off for the whole node**.
- `Node.client_id` → `clientId` — participant identity and the `discoverSelf` comparison.
- `AnalysisNode.node_id` → `nodeId` (the Java field is renamed alongside the annotation; it has no readers).

`HubResponseContainer` is **unchanged**: both `HubClient` calls target *collection* endpoints, whose `{ data, meta }` envelope long predates this release. The Hub's record envelope does not reach this client.

The integration tests build their stub bodies by serialising these same DTOs through Jackson, so only the four query-key assertions in `HttpHubClientIT` needed touching.

## System tests

`system-tests/environment/resources/hub/setup-hub-resources.sh` provisions its fixtures through the Hub and authup REST APIs, so it is affected on both sides:

- **Request bodies** — the six `*-setup-template.json` files move to camelCase. That includes `client-account-setup-template.json`, which posts to **authup** (`secret_hashed` → `secretHashed`, `is_confidential` → `isConfidential`): authup renamed in lockstep. Hub's validator drops an unknown body key silently, so a stale `realm_id` would have created the entity with no realm rather than erroring.
- **Response reads** — `jq -r '.id'` → `jq -r '.data.id // empty'` at all 14 record-creating calls. The two collection reads (`.data[0].id`) already matched the envelope and just gained the same guard.

The `// empty` is load-bearing. Without it `jq -r '.data.id'` emits the **string** `"null"` for a missing key, which the script's `if [ -z "${X}" ]` guards accept as success and then propagate as a literal `null` id into every subsequent request. Verified:

```console
$ echo '{"data":{"id":"abc"},"meta":{}}' | jq -r '.data.id // empty'
abc
$ echo '{"id":"abc"}' | jq -r '.data.id // empty'          # pre-0.13.0 shape
                                                           # → empty, guard fires
```

## Deliberately not renamed

The OAuth2 surface is spec-frozen and stays snake_case — `HubOIDCAuthenticator`'s `client_id` form parameter, the same in `system-tests/tests/message-broker/auth.go`, and `jq -r '.access_token'`. Also untouched: the shell variable names in `setup.sh`, the keycloak realm export, and the socket.io message DTOs (`HubMessageMetadata`, `HubMessageSender`, `HubMessageRecipient`), which were already camelCase.

## The system-test environment had to move too (commits 2–5)

`Run System Tests` was **already failing before this PR**, and for a related reason. The stack pinned `ghcr.io/privateaim/hub:0.8.31` but pulled `authup/authup` **unpinned**, so `latest` drifted onto a release 0.8.31 cannot talk to and Hub core stopped becoming healthy. The last green CI run was 2026-06-20.

Five things were needed to get the stack working on 0.13.0, each found by running it rather than by reading source:

- Both Hub images → `0.13.0`; authup pinned to `1.0.0-beta.57`, the version Hub 0.13.0 declares across its `@authup/*` dependencies.
- `HARBOR_URL: ${HARBOR_URL:-}` **removed**. 0.13.0 validates `harborURL` as a URL when the key is present, and the empty string aborts startup with `Property harborURL is invalid`. Harbor is unused here, so it is better left unset than empty.
- **Hub permissions are provisioned into authup.** Since 0.13.0 the authorization middleware genuinely enforces permissions where it previously ran in dry-run mode, and the Hub does not register its own permission names. Without them every write fails with `The project_create permission could not be resolved`. A new `authup-provisioning.mjs` declares all 30 `PermissionName` values and is mounted at `/usr/src/app/writable/provisioning/hub.mjs`; authup's built-in `admin` role resolves them via its `globalPermissions: ['*']`. This mirrors `buildAuthupProvisioning()` in `@privateaim/server-test-kit`.
- **The node client accounts needed an explicit auth method.** Under beta.57 `isConfidential` is gone from the client read model and no longer implies secret-based authentication, so the template produced clients with `authMethod: "none"` and `grantTypes: null`. Every client-credentials request returned `invalid_client`, the broker could never obtain a Hub token, and `GET /analyses/{id}/participants/self` answered **502** — exactly what CI showed. The template now declares `authMethod: "secret"` and `grantTypes: "client_credentials"`.
- **The messenger needed a database and authup credentials.** With discovery fixed, the send/receive test still reported `sent (10) and received (0) differs`. The messenger container was **crash-looping** the whole time — nothing in the harness waits on it, only on core. Two separate gaps: 0.13.0's messenger gained a durable mailbox and now needs a datasource where 0.8.31 was a stateless relay (`The database configuration could not be read from env variables.`), and once it booted, every socket handshake was rejected with `Property token is invalid` because its authorization middleware introspects incoming tokens through an authup client token creator built from `CLIENT_ID` / `CLIENT_SECRET` / `REALM`, which core is given and the messenger was not.

Two things worth noting for review:

- The Hub's **read** endpoints are not permission-gated, so the node clients need no role or permission binding of their own. Only writes are, and the provisioning script makes those with the admin token.
- The broker's socket contract needed **no** changes. Event names, the `{to:[{type,id}], data, metadata}` payload and the `client-connection:${id}` room key are identical between the two Hub versions, and the messenger DTOs were already camelCase. Every messenger problem here was environment configuration.

## Verification

I brought the stack up locally against Hub 0.13.0 and iterated on it until it worked. Core reaches `healthy`, and `setup-hub-resources.sh` completes end to end — three clients, project, analysis, three nodes, three project nodes, three analysis nodes. After a clean provisioning run the node A client obtains a token with **no manual patching**, and both queries the broker makes succeed with it (`/analysis-nodes` → the analysis's 3 nodes; `/nodes?filter[clientId]` → exactly 1, carrying a non-null `publicKey`).

Both of the broker's queries were also exercised old key versus new, using the admin token:

```console
# GET /analysis-nodes — the participant lookup
filter[analysisId]=<real id>    → total 3     ✅
filter[analysis_id]=<BOGUS id>  → total 3     ⬅ filter pruned; every node returned

# GET /nodes — the public-key lookup
filter[clientId]=<real id>      → total 1     ✅ (the client requires exactly 1)
filter[client_id]=<real id>     → total 3     ⬅ NoMatchingNodeFoundException
```

That first line is the confidentiality issue, demonstrated rather than argued: a deliberately non-existent analysis id still returned all three analysis nodes.

The `include=node` payload also confirms the DTO annotations — the relation carries `clientId`, `publicKey`, `robotId`, `externalName`, `realmId`, `registryId`, `registryProjectId`, `createdAt`, `updatedAt`.

The messenger relay was verified separately, with two node clients connected to it over socket.io: A emits `send` addressed to B's client id and B receives it, `from` resolving to A's client identity. Both messenger changes are required — with either missing the relay stays silent rather than erroring, because the sender's acknowledgement callback still reports success, the same failure shape as a pruned rapiq filter.

**Not verified locally:** `mvn verify`, and the node half of the system tests. There is no JVM or Maven on the machine I worked from, and the node compose builds its image from `target/*.jar`, so that half is only exercised by CI. The Java changes are annotation strings and query-parameter strings; no control flow moved.

## Ordering

Independent of the other 0.13.0 follow-ups ([hub-python-client#129](https://github.com/PrivateAIM/hub-python-client/pull/129), [node-ui#401](https://github.com/PrivateAIM/node-ui/pull/401)) — this repo talks to the Hub directly. It must land **with** the 0.13.0 rollout, though: the current `develop` and 0.13.0 cannot interoperate in either direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated Hub requests and responses to use consistent camelCase field names.
  - Improved handling of wrapped Hub API responses and missing resource identifiers.

- **System Tests**
  - Updated setup templates and integration checks for the revised Hub API format.
  - Added Hub provisioning permissions and refreshed local Hub service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->